### PR TITLE
Feature using ResultWriter field

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,14 +9,14 @@
     "@types/aws-lambda": "^8.10.137",
     "@types/jest": "^29.5.12",
     "@types/node": "20.11.30",
-    "aws-cdk": "2.141.0",
+    "aws-cdk": "2.179.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.2",
     "typescript": "~5.3.3"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.141.0",
+    "aws-cdk-lib": "2.179.0",
     "constructs": "^10.0.0"
   }
 }


### PR DESCRIPTION
When moving a large number of files, it may exceed the payload limits of Step Functions. Therefore, change it to use the [ResultWriter](https://docs.aws.amazon.com/ja_jp/step-functions/latest/dg/input-output-resultwriter.html) field.